### PR TITLE
feat: 行動ガチャの行動リストをレベル別に管理できるようにリファクタリング

### DIFF
--- a/src/components/Lv1/ActionGacha.vue
+++ b/src/components/Lv1/ActionGacha.vue
@@ -58,7 +58,20 @@
 </template>
 
 <script setup>
-import { ref, reactive } from 'vue'
+import { ref, reactive, computed } from 'vue'
+import { actionsByLevel } from '@/constants/actions.js'
+
+// 親からレベル情報を受け取る
+const props = defineProps({
+  level: {
+    type: Number,
+    required: true,
+    default: 1
+  }
+})
+
+// 現在のレベルに応じた行動リストを取得
+const actionDatabase = computed(() => actionsByLevel[props.level] || [])
 
 // リアクティブデータ
 const isProcessing = ref(false)
@@ -75,38 +88,7 @@ const treasures = reactive([
   { isSelected: false, isOpening: false, isGlowing: false }
 ])
 
-// 行動データベース
-const actionDatabase = [
-  // 運動カテゴリ
-  { name: '5分散歩', category: '運動', description: '外の空気を吸いながら軽く歩いてみましょう', duration: '5分' },
-  { name: 'ストレッチ', category: '運動', description: '肩や首をゆっくりと伸ばしてリフレッシュ', duration: '3分' },
-  { name: '階段昇降', category: '運動', description: '階段を使って軽い運動をしてみましょう', duration: '2分' },
-  { name: 'ラジオ体操', category: '運動', description: '懐かしいラジオ体操で体を動かそう', duration: '6分' },
-  
-  // リラックスカテゴリ
-  { name: '深呼吸', category: 'リラックス', description: 'ゆっくりと深く呼吸して心を落ち着けましょう', duration: '2分' },
-  { name: '瞑想', category: 'リラックス', description: '静かに座って心を空っぽにしてみましょう', duration: '5分' },
-  { name: 'お茶を飲む', category: 'リラックス', description: '温かい飲み物でほっと一息つきましょう', duration: '10分' },
-  { name: '音楽鑑賞', category: 'リラックス', description: '好きな音楽を聴いてリラックスしましょう', duration: '15分' },
-  
-  // 創作活動カテゴリ
-  { name: '絵を描く', category: '創作活動', description: '思いつくままに絵を描いてみましょう', duration: '15分' },
-  { name: '日記を書く', category: '創作活動', description: '今日の出来事や気持ちを書き留めましょう', duration: '10分' },
-  { name: '写真を撮る', category: '創作活動', description: '身の回りの美しいものを写真に収めましょう', duration: '10分' },
-  { name: '料理をする', category: '創作活動', description: '簡単な料理やお菓子作りに挑戦しましょう', duration: '30分' },
-  
-  // 社交カテゴリ
-  { name: '友人に連絡', category: '社交', description: '久しぶりの友人にメッセージを送ってみましょう', duration: '5分' },
-  { name: '家族と話す', category: '社交', description: '家族との時間を大切にしましょう', duration: '15分' },
-  { name: 'SNS投稿', category: '社交', description: '今日の良いことをSNSでシェアしましょう', duration: '5分' },
-  { name: 'オンライン通話', category: '社交', description: '大切な人とビデオ通話をしてみましょう', duration: '20分' },
-  
-  // セルフケアカテゴリ
-  { name: '入浴', category: 'セルフケア', description: 'ゆっくりとお風呂に入ってリフレッシュ', duration: '20分' },
-  { name: '読書', category: 'セルフケア', description: '好きな本を読んで知識や想像力を育みましょう', duration: '30分' },
-  { name: '部屋の整理', category: 'セルフケア', description: '身の回りを整理して気分をスッキリさせましょう', duration: '15分' },
-  { name: '植物の世話', category: 'セルフケア', description: '植物に水をあげて成長を見守りましょう', duration: '5分' }
-]
+
 
 // カテゴリ別の色設定
 const categoryColors = {
@@ -147,8 +129,8 @@ const selectTreasure = (index) => {
     treasures[index].isOpening = true
     
     // ランダムに行動を選択
-    const randomIndex = Math.floor(Math.random() * actionDatabase.length)
-    selectedAction.value = actionDatabase[randomIndex]
+    const randomIndex = Math.floor(Math.random() * actionDatabase.value.length)
+    selectedAction.value = actionDatabase.value[randomIndex]
     
     // 0.5秒後に結果表示
     setTimeout(() => {

--- a/src/components/Lv1/MainView.vue
+++ b/src/components/Lv1/MainView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <MoodInput />
-    <ActionGacha />
+    <ActionGacha :level="1" />
     <MoodChart />
     <MoodCalendar />
     

--- a/src/components/Lv2/MainView.vue
+++ b/src/components/Lv2/MainView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <MoodInput />
-    <ActionGacha />
+    <ActionGacha :level="2" />
     <MemoTracker />
     <MoodChart />
     <MoodCalendar />

--- a/src/components/Lv3/MainView.vue
+++ b/src/components/Lv3/MainView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <MoodInput />
-    <ActionGacha />
+    <ActionGacha :level="3" />
     <KuesutMove />
     <MoodChart />
     <MoodCalendar />

--- a/src/components/Lv4/MainView.vue
+++ b/src/components/Lv4/MainView.vue
@@ -3,7 +3,7 @@
     <!-- 既存流用コンポーネント -->
     <div class="section">
       <MoodInput />
-      <ActionGacha />
+      <ActionGacha :level="4" />
     </div>
 
     <!-- Lv4特有の要素 -->

--- a/src/components/Lv5/MainView.vue
+++ b/src/components/Lv5/MainView.vue
@@ -3,7 +3,7 @@
     <!-- 既存流用コンポーネント -->
     <div class="section">
       <MoodInput />
-      <ActionGacha />
+      <ActionGacha :level="5" />
     </div>
 
     <!-- Lv5特有の要素 -->

--- a/src/constants/actions.js
+++ b/src/constants/actions.js
@@ -1,0 +1,57 @@
+const actionsLv1 = [
+  { name: '深呼吸を3回する', category: 'リラックス', description: 'ゆっくりと深く呼吸して心を落ち着けましょう', duration: '1分' },
+  { name: '水を一口飲む', category: 'セルフケア', description: '喉を潤し、体を目覚めさせましょう', duration: '1分' },
+  { name: 'カーテンを開ける', category: 'セルフケア', description: '部屋に光を取り入れ、気分転換をしましょう', duration: '1分' },
+  { name: '好きな音楽を1曲聴く', category: 'リラックス', description: '心地よい音楽で気分をリフレッシュしましょう', duration: '3分' },
+  { name: '目を閉じて1分間休む', category: 'リラックス', description: '何も考えず、ただ目を閉じて休みましょう', duration: '1分' },
+  { name: '手足を軽く伸ばす', category: '運動', description: 'ベッドや椅子に座ったまま、軽く体を動かしましょう', duration: '2分' },
+  { name: '温かい飲み物を飲む', category: 'セルフケア', description: '温かい飲み物で心身を落ち着かせましょう', duration: '5分' }
+];
+
+const actionsLv2 = [
+  { name: '5分散歩（家の中でもOK）', category: '運動', description: 'ゆっくり歩いて体を動かしましょう', duration: '5分' },
+  { name: 'ストレッチを3分する', category: '運動', description: '肩や首、手足をゆっくり伸ばしてリフレッシュ', duration: '3分' },
+  { name: '窓を開けて外の空気を吸う', category: 'セルフケア', description: '新鮮な空気を取り入れ、気分を入れ替えましょう', duration: '2分' },
+  { name: '好きな動画を1本見る', category: 'リラックス', description: '短めの好きな動画を見て気分転換をしましょう', duration: '10分' },
+  { name: '簡単な掃除を5分する', category: 'セルフケア', description: '身の回りの簡単な場所を少しだけきれいにしましょう', duration: '5分' },
+  { name: '日記を1行書く', category: '創作活動', description: '今日の気持ちや出来事をたった1行でも書き留めましょう', duration: '3分' },
+  { name: '植物に水をやる（もしあれば）', category: 'セルフケア', description: '植物の世話をして、小さな生命に触れましょう', duration: '5分' }
+];
+
+const actionsLv3 = [
+  { name: '今日のTo-Doリストを3つ書く', category: '創作活動', description: '今日やるべきことを3つだけ書き出し、達成感を味わいましょう', duration: '5分' },
+  { name: '友人にメッセージを送る', category: '社交', description: '久しぶりの友人や大切な人に短いメッセージを送ってみましょう', duration: '5分' },
+  { name: '簡単な料理を作る', category: '創作活動', description: '手軽に作れる料理に挑戦し、達成感を味わいましょう', duration: '30分' },
+  { name: '読書を10分する', category: 'セルフケア', description: '好きな本や雑誌を10分だけ読んで、知識や想像力を育みましょう', duration: '10分' },
+  { name: '部屋の整理を15分する', category: 'セルフケア', description: '身の回りの気になる場所を15分だけ整理整頓しましょう', duration: '15分' },
+  { name: '新しい情報を1つ調べる', category: '創作活動', description: '興味のあることや知りたいことを一つだけ調べてみましょう', duration: '10分' },
+  { name: '感謝できることを3つ見つける', category: 'リラックス', description: '今日あった良いことや感謝できることを3つ書き出してみましょう', duration: '5分' }
+];
+
+const actionsLv4 = [
+  { name: '目標達成に向けた小さなタスクを1つ実行する', category: '創作活動', description: '中期目標達成のための具体的な一歩を踏み出しましょう', duration: '15分' },
+  { name: '目標に関連する情報を調べる', category: '創作活動', description: '目標達成に必要な知識や情報を収集しましょう', duration: '20分' },
+  { name: '運動を20分する', category: '運動', description: 'ウォーキングや軽い筋トレなど、体を動かす時間を20分作りましょう', duration: '20分' },
+  { name: '長めの入浴をする', category: 'セルフケア', description: 'ゆっくり湯船に浸かり、心身をリラックスさせましょう', duration: '30分' },
+  { name: '仲の良い人とゆっくり話す', category: '社交', description: '仲の良い人と今日の出来事や感じたことを共有する時間を作りましょう', duration: '20分' },
+  { name: '自分の強みを3つ書き出す', category: 'セルフケア', description: '自分の良いところや得意なこと、新しくできるようになったことを3つ書き出し、自己肯定感を高めましょう', duration: '10分' },
+  { name: '新しい知識を1つ学ぶ', category: '創作活動', description: '興味のある分野の新しい知識を一つ学びましょう', duration: '15分' }
+];
+
+const actionsLv5 = [
+  { name: '長期目標の進捗を振り返る', category: '創作活動', description: '設定した長期目標の進捗を確認し、必要であれば計画を見直しましょう', duration: '30分' },
+  { name: '新しい挑戦のための準備を1つする', category: '創作活動', description: '新しいスキル習得やプロジェクト開始に向けた準備を一つ進めましょう', duration: '45分' },
+  { name: '新しい趣味を探す', category: '社交', description: '視野を広げ、人生を豊かにする新しい趣味や活動について情報収集してみましょう', duration: '20分' },
+  { name: 'ボランティア活動について調べる', category: '社交', description: '社会貢献できるボランティア活動について調べてみましょう', duration: '20分' },
+  { name: '新しい出会いの場を探す', category: '社交', description: '興味のあるコミュニティやイベントについて調べてみましょう', duration: '20分' },
+  { name: '自分の価値観を再確認する', category: 'セルフケア', description: '自分にとって何が大切か、どんなことを重視したいか再確認しましょう', duration: '15分' },
+  { name: '自己投資になる行動を1つする', category: 'セルフケア', description: '将来の自分への投資として、学びや経験に繋がる行動を一つ選びましょう', duration: '30分' }
+];
+
+export const actionsByLevel = {
+  1: actionsLv1,
+  2: actionsLv2,
+  3: actionsLv3,
+  4: actionsLv4,
+  5: actionsLv5,
+};


### PR DESCRIPTION
- ActionGacha.vueから行動リストをsrc/constants/actions.jsに分離。
- ActionGacha.vueがlevel propを受け取り、レベルに応じた行動リストを表示するように修正。
- 各LvのMainView.vueでActionGachaコンポーネントにlevel propを渡すように修正。
- 各レベルの行動リストを、ユーザーのモチベーションレベルの基準に合わせて調整。